### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ install about a missing dns_sd.h file. If so, install the Apple mDNS SDK:
 ### Browser
 
 The browser is a discovery service that can be run to automatically detect the
-AirPlay-compatiable devices on the local network(s). Try only to create one
+AirPlay-compatible devices on the local network(s). Try only to create one
 browser per node instance, and if it's no longer needed stop it.
 
 Create a browser using the `createBrowser` method:


### PR DESCRIPTION
@benvanik, I've corrected a typographical error in the documentation of the [node-airplay](https://github.com/benvanik/node-airplay) project. Specifically, I've changed compatiable to compatible. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
